### PR TITLE
Add shebang to omm_builder.py

### DIFF
--- a/omm_builder.py
+++ b/omm_builder.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import sys
 import filecmp


### PR DESCRIPTION
This tells UNIX-like operating systems (Linux BSD, and MacOS) what program to use as an interpreter for the script.